### PR TITLE
Adding permissions to the Baseline RO for new AI query

### DIFF
--- a/policies/BaselineReadOnly.json
+++ b/policies/BaselineReadOnly.json
@@ -37,6 +37,7 @@
         "cloudtrail:LookupEvents",
         "cloudwatch:Describe*",
         "cloudwatch:Get*",
+        "cloudwatch:GenerateQuery",
         "cloudwatch:List*",
         "codeartifact:Describe*",
         "codeartifact:List*",


### PR DESCRIPTION
This permission will allow users of log insight to use the AI powered generative query. Note: Only available in us-east-1 and us-west-2 at the moment